### PR TITLE
Sibling: Add quotes and hash to issue output

### DIFF
--- a/packages/label-sync-core/src/handlers/siblings/reporter.ts
+++ b/packages/label-sync-core/src/handlers/siblings/reporter.ts
@@ -47,7 +47,7 @@ export function createTerminalReport(report: SiblingSyncReport): string {
     return issues
       .map(
         issue => ml`
-          | - ${issue.issue.title} (${issue.issue.number})
+          | - "${issue.issue.title}" (#${issue.issue.number})
           | Added ${issue.siblings.map(l => l.name).join(', ')}.
         `,
       )

--- a/packages/label-sync-core/tests/handlers/siblings/__snapshots__/reporter.test.ts.snap
+++ b/packages/label-sync-core/tests/handlers/siblings/__snapshots__/reporter.test.ts.snap
@@ -5,7 +5,7 @@ exports[`sibling sync reporter correctly generates report 1`] = `
 (dry run: "false")
 
 Created siblings:
-- Another Issue Title (5)
+- "Another Issue Title" (#5)
 Added basic, kind/bug."
 `;
 


### PR DESCRIPTION
This adds quotes to makes it clearer that this is an issue title, and a hash to signify that it is an issue ID.

Might possibly also be useful in other locations if there is similar output.