### PR TITLE
Add Root To Installed Packages

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -8,7 +8,7 @@ services:
     type: web
     env: node
     region: frankfurt
-    buildCommand: yarn workspaces focus @labelsync/server
+    buildCommand: yarn workspaces focus labelsync @labelsync/server
     startCommand: yarn workspace @labelsync/server start
     envVars:
       - key: NODE_VERSION
@@ -35,7 +35,7 @@ services:
     type: web
     env: node
     region: frankfurt
-    buildCommand: yarn workspaces focus @labelsync/sync
+    buildCommand: yarn workspaces focus labelsync @labelsync/sync
     startCommand: yarn workspace @labelsync/sync start
     envVars:
       - key: NODE_VERSION


### PR DESCRIPTION
This PR fixes the Render startup script by adding `labelsync` (i.e. root package) to the install command.